### PR TITLE
Filter out empty lines in fw_env.config

### DIFF
--- a/lib/uboot_env/config.ex
+++ b/lib/uboot_env/config.ex
@@ -30,10 +30,10 @@ defmodule UBootEnv.Config do
   def decode(config) do
     [config] =
       config
-      |> String.split("\n", trim: true)
+      |> String.split("\n")
       |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
       |> Enum.reject(&String.starts_with?(&1, "#"))
-      |> Enum.reject(fn (s) -> String.length(s) == 0 end)
 
     [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
 

--- a/lib/uboot_env/config.ex
+++ b/lib/uboot_env/config.ex
@@ -33,6 +33,7 @@ defmodule UBootEnv.Config do
       |> String.split("\n", trim: true)
       |> Enum.map(&String.trim/1)
       |> Enum.reject(&String.starts_with?(&1, "#"))
+      |> Enum.reject(fn (s) -> String.length(s) == 0 end)
 
     [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
 


### PR DESCRIPTION
I have no idea what changed, but suddenly my nerves-board wouldn't boot up anymore raising an error about reading the `fw_env.config` file. It turned out that the `decode` function couldn't handle the blank lines, which are present in `fw_env.config`:

```
iex(3)> [config] = config |> String.split("\n", trim: true) |> Enum.map(&String.trim/1) |> Enum.reject(&String.starts_with?(&1, "#")) 
** (MatchError) no match of right hand side value: ["", "/dev/mmcblk0\t0x2000\t\t0x2000\t\t0x200\t\t\t16", ""]
    (stdlib) erl_eval.erl:453: :erl_eval.expr/5
    (iex) lib/iex/evaluator.ex:257: IEx.Evaluator.handle_eval/5
    (iex) lib/iex/evaluator.ex:237: IEx.Evaluator.do_eval/3
    (iex) lib/iex/evaluator.ex:215: IEx.Evaluator.eval/3
    (iex) lib/iex/evaluator.ex:103: IEx.Evaluator.loop/1
    (iex) lib/iex/evaluator.ex:27: IEx.Evaluator.init/4
```

Therefore I added `Enum.reject(fn (s) -> String.length(s) == 0 end)` to the game:
```
iex(3)> [config] = config |> String.split("\n", trim: true) |> Enum.map(&String.trim/1) |> Enum.reject(&String.starts_with?(&1, "#")) |> Enum.reject(fn (s) -> String.length(s) == 0 end)
["/dev/mmcblk0\t0x2000\t\t0x2000\t\t0x200\t\t\t16"]
```

I don't know what suddenly caused the issue, but could it be that my editor (VS Code) modified the line-endings?

Anyway I think filtering out empty lines is an extra security.