### PR TITLE
Update spacing test with trailing whitespace

### DIFF
--- a/test/fixtures/spaces_fw_env.config
+++ b/test/fixtures/spaces_fw_env.config
@@ -1,3 +1,7 @@
 # Configuration file for fw_(printenv/setenv) utility.
 
 /dev/mtd3        0x0        0x1000   0x10000
+
+# This next line has trailing whitespace. IT IS NEEDED FOR A TEST
+    
+


### PR DESCRIPTION
The issue identified in the previous commits was found on Windows due to
different line endings. It would have also happened with trailing
whitespace. This updates the unit test that deals with spacing exercises
the issue that was fixed.