### PR TITLE
Rewrite encode to use iodata

### DIFF
--- a/test/uboot_env_test.exs
+++ b/test/uboot_env_test.exs
@@ -84,7 +84,7 @@ defmodule UBootEnvTest do
     {:ok, fd} = File.open(dev_name)
 
     {:ok, bin} = :file.pread(fd, dev_offset, env_size)
-    encoded = UBootEnv.encode(kv, env_size)
+    encoded = UBootEnv.encode(kv, env_size) |> IO.iodata_to_binary()
     assert bin == encoded
   end
 


### PR DESCRIPTION
This removes a lot of temporary binary creation from the encode process.
Erlang's file I/O already supports iodata, so even though this is a
breaking API change (the spec said binary and not iodata), it will
likely not require any changes to the code that uses it.