### PR TITLE
Refactor write and decode

### DIFF
--- a/lib/uboot_env/tools.ex
+++ b/lib/uboot_env/tools.ex
@@ -30,12 +30,15 @@ defmodule UBootEnv.Tools do
   end
 
   @doc """
-  Decode the output of `fw_printenv`
+  Decode a list of fw_env.config key value pairs into a map
   """
   @spec decode(String.t()) :: map()
-  def decode(env) when is_binary(env) do
-    String.split(env, "\n", trim: true)
-    |> UBootEnv.decode()
+  def decode(env) do
+    env
+    |> String.split("\n", trim: true)
+    |> Enum.map(&String.split(&1, "=", parts: 2))
+    |> Enum.map(fn [k, v] -> {k, v} end)
+    |> Enum.into(%{})
   end
 
   defp exec(cmd, args \\ []) do

--- a/test/uboot_env_test.exs
+++ b/test/uboot_env_test.exs
@@ -95,4 +95,28 @@ defmodule UBootEnvTest do
     error = UBootEnv.load(dev_name, dev_offset, env_size)
     assert match?({:error, :empty}, error)
   end
+
+  test "decoding what is encoded" do
+    kv = %{
+      "test_value_with_whitespace" => "a b\nc\td e",
+      "test_empty_value" => "",
+      "" => "empty key",
+      "a.nerves_fw_application_part0_devpath" => "/dev/mmcblk0p3",
+      "a.nerves_fw_application_part0_fstype" => "ext4",
+      "a.nerves_fw_application_part0_target" => "/root",
+      "a.nerves_fw_architecture" => "arm",
+      "a.nerves_fw_author" => "The Nerves Team",
+      "a.nerves_fw_description" => "",
+      "a.nerves_fw_platform" => "rpi",
+      "a.nerves_fw_product" => "Nerves Firmware",
+      "a.nerves_fw_version" => "",
+      "nerves_fw_active" => "a",
+      "nerves_fw_devpath" => "/dev/mmcblk0"
+    }
+
+    encoded = UBootEnv.encode(kv, 128 * 1024) |> IO.iodata_to_binary()
+    {:ok, decoded} = UBootEnv.decode(encoded)
+
+    assert decoded == kv
+  end
 end


### PR DESCRIPTION
This refactors the code involved with writing and decoding U-Boot
environments. The original purpose was to reduce the amount of
binary garbage that got generated on load, but this contains some
cleanup as well.

On one system, then reduces the garbage created by about 2 MB. This
garbage could be cleaned up manually by calling
`:erlang.garbage_collect/1`, but it stayed around for a long time. Now
the total memory for the processes that had the garbage is in the 40 KB
range without a garbage collect.

The previous commit that uses iodata likely had an effect as well.