### PR TITLE
Sync writes to ensure changes are written to disk

### DIFF
--- a/lib/uboot_env/io.ex
+++ b/lib/uboot_env/io.ex
@@ -177,6 +177,7 @@ defmodule UBootEnv.IO do
     case File.open(location.path, [:raw, :binary, :write, :read]) do
       {:ok, fd} ->
         rc = :file.pwrite(fd, location.offset, contents)
+        _ = :file.sync(fd)
         _ = File.close(fd)
         rc
 


### PR DESCRIPTION
Sync writes to ensures that any buffers kept by the operating system (not by the Erlang runtime system) are written to disk

Motivation: On our platform, if we pull the plug directly after writing envs with put, sometimes the result would not actually be synced to disk. This happens even if we read them back with get before pulling the plug.

This PR should ensure that changes are synced