### PR TITLE
Add Dependabot automerge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ defaults: &defaults
     LC_ALL: C.UTF-8
 
 latest: &latest
-  pattern: "^1.15.6-erlang-26.*$"
+  pattern: "^1.15.7-erlang-26.*$"
 
 tags: &tags
   [
-    1.15.6-erlang-26.1.1-alpine-3.18.2,
+    1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
     1.13.4-erlang-25.3.2-alpine-3.18.0,
     1.12.3-erlang-24.3.4.11-alpine-3.18.0,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,19 @@ defaults: &defaults
 latest: &latest
   pattern: "^1.15.6-erlang-26.*$"
 
+tags: &tags
+  [
+    1.15.6-erlang-26.1.1-alpine-3.18.2,
+    1.14.5-erlang-25.3.2-alpine-3.18.0,
+    1.13.4-erlang-25.3.2-alpine-3.18.0,
+    1.12.3-erlang-24.3.4.11-alpine-3.18.0,
+    1.11.4-erlang-23.3.4.18-alpine-3.16.2,
+    1.10.4-erlang-23.3.4.18-alpine-3.16.2,
+    1.9.4-erlang-22.3.4.23-alpine-3.13.6,
+    1.8.2-erlang-22.3.4.23-alpine-3.13.6,
+    1.7.4-erlang-21.3.8.24-alpine-3.13.3
+  ]
+
 jobs:
   build-test:
     parameters:
@@ -47,6 +60,25 @@ jobs:
             - _build
             - deps
 
+  automerge:
+    docker:
+        - image: alpine:3.18.4
+    <<: *defaults
+    steps:
+      - run:
+          name: Install GitHub CLI
+          command: apk add --no-cache build-base github-cli
+      - run:
+          name: Attempt PR automerge
+          command: |
+            author=$(gh pr view "${CIRCLE_PULL_REQUEST}" --json author --jq '.author.login' || true)
+
+            if [ "$author" = "app/dependabot" ]; then
+              gh pr merge "${CIRCLE_PULL_REQUEST}" --auto --rebase || echo "Failed trying to set automerge"
+            else
+              echo "Not a dependabot PR, skipping automerge"
+            fi
+
 workflows:
   checks:
     jobs:
@@ -54,14 +86,11 @@ workflows:
           name: << matrix.tag >>
           matrix:
             parameters:
-              tag: [
-                1.15.6-erlang-26.1.1-alpine-3.18.2,
-                1.14.5-erlang-25.3.2-alpine-3.18.0,
-                1.13.4-erlang-25.3.2-alpine-3.18.0,
-                1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-                1.11.4-erlang-23.3.4.18-alpine-3.16.2,
-                1.10.4-erlang-23.3.4.18-alpine-3.16.2,
-                1.9.4-erlang-22.3.4.23-alpine-3.13.6,
-                1.8.2-erlang-22.3.4.23-alpine-3.13.6,
-                1.7.4-erlang-21.3.8.24-alpine-3.13.3
-              ]
+              tag: *tags
+
+      - automerge:
+          requires: *tags
+          context: org-global
+          filters:
+            branches:
+              only: /^dependabot.*/


### PR DESCRIPTION
Adds an extra job that will run only on dependabot PR's, require all previous jobs to be successful, and require the PR was created by dependabot. If all conditions are met, it will automatically merge the dependabot PR