### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UBootEnv
 
 [![Hex version](https://img.shields.io/hexpm/v/uboot_env.svg "Hex version")](https://hex.pm/packages/uboot_env)
-[![API docs](https://img.shields.io/hexpm/v/uboot_env.svg?label=hexdocs "API docs")](https://hexdocs.pm/uboot_env/UBootEnv.html)
+[![API docs](https://img.shields.io/hexpm/v/uboot_env.svg?label=hexdocs "API docs")](https://uboot-env.hexdocs.pm/UBootEnv.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/uboot_env/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/uboot_env/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/uboot_env)](https://api.reuse.software/info/github.com/nerves-project/uboot_env)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://uboot-env.hexdocs.pm/UBootEnv.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>